### PR TITLE
Fix title tag, and fix accessibility for img

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -41,14 +41,15 @@ limitations under the License.
 <!-- As a heading -->
 <div class="jumbotron jumbotron-fluid py-4" style="text-align: center; background-color: #f5f5f5;">
 <div class="container">
-    <h4>Kuzushiji OCR</h1>
+    <h4>Kuzushiji OCR</h4>
 </div>
 </div>
 <div class="container">
 <img id="content-img" 
 style="display: none"
 class="centered" 
-src="images/7.jpg"></img>
+src="images/7.jpg"
+alt="Kuzushiji example image" />
 <div class="row my-4">
     <div class="col mx-5 my-4">
         <canvas id="content-canvas" 


### PR DESCRIPTION
Not sure whether the title should be `h4` or `h1`. Used `h4` as it was on the left side of the statement… but for screen readers, it would be better to go with `h1` I think.

There is also a single image without alt/title/aria-. Added an alt, but other attributes can be added later for accessibility :+1: 